### PR TITLE
getDevices: return an error if the request failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,8 +115,18 @@ var findmyphone = {
 
 		findmyphone.init(function(error, response, body) {
 
-			if (!response || response.statusCode != 200) {
-				return callback(error);
+			if (error) {
+				callback(error);
+			}
+
+			if (!response) {
+				return callback('Received no response from iCloud API.');
+			}
+
+		  	if (!response.statusCode !== 200) {
+				var errorMessage = 'iCloud request failed.\nStatus code: ' + response.statusCode;
+				errorMessage += body ? '\nResponse body: ' + body.content : '';
+				return callback(errorMessage);
 			}
 
 			var devices = [];


### PR DESCRIPTION
Currently the ```getDevices``` function calls the callback with two undefined values if the request to the api failed. This caused the problem described in #15 and is generally not what a developer expects. The callback should always return either an error or the result.