### PR TITLE
Only ping the user's own device(s), don't wake the whole family!

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ var findmyphone = {
 						"timezone": "US/Eastern",
 						"inactiveTime": 3571,
 						"apiVersion": "3.0",
-						"fmly": true
+						"fmly": false  // Only your devices, not family members'!
 					}
 				}
 			};


### PR DESCRIPTION
If the user has Family Sharing set up, the initClient API returns all family members' devices as well, which by default will also be pinged. If the user is not using Family Sharing, this change has no effect and works the same as before.